### PR TITLE
bitsy0 pcf: Change UART pins

### DIFF
--- a/icebitsy/icebitsy0.pcf
+++ b/icebitsy/icebitsy0.pcf
@@ -7,9 +7,9 @@ set_io -nowarn USB_P      43
 set_io -nowarn USB_N      42
 set_io -nowarn USB_DET    38
 
-# RS232 - pin 0 and 1 on the bitsy1
-set_io -nowarn RX         47
-set_io -nowarn TX         44
+# RS232 - pins on the "programming connector"
+set_io -nowarn RX         18
+set_io -nowarn TX         19
 
 # LEDs and Button
 set_io -nowarn BTN_N      10


### PR DESCRIPTION
Theses are the two pins that have been used for the
bootloader and other platform files until now ...

They are on the "programming" connector side.
The current pins (47/44) are not next to each other
and in the middle of one of the side, not great so
this is probably better and doesn't matter much since
it's v0 anyway.

Signed-off-by: Sylvain Munaut <tnt@246tNt.com>